### PR TITLE
Break down select output into composable components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.66.1", stable, beta, nightly]
+        rust: ["1.70", stable, beta, nightly]
 
     steps:
       - uses: actions/checkout@v3

--- a/turbosql-impl/Cargo.toml
+++ b/turbosql-impl/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0 OR CC0-1.0"
 name = "turbosql-impl"
 repository = "https://github.com/trevyn/turbosql"
-rust-version = "1.66"
+rust-version = "1.70"
 version = "0.8.0"
 
 [lib]

--- a/turbosql/Cargo.toml
+++ b/turbosql/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0 OR CC0-1.0"
 name = "turbosql"
 readme = "README.md"
 repository = "https://github.com/trevyn/turbosql"
-rust-version = "1.66"
+rust-version = "1.70"
 version = "0.8.0"
 
 [dependencies]

--- a/turbosql/tests/integration_test.rs
+++ b/turbosql/tests/integration_test.rs
@@ -98,6 +98,25 @@ fn integration_test() {
 		}
 	);
 
+	assert_eq!(
+		select!(Option<NameAndAgeResult> r#""Martin Luther" AS name, field_u8 AS age FROM personintegrationtest"#)
+			.unwrap(),
+		Some(NameAndAgeResult {
+			name: Some("Martin Luther".into()),
+			age: Some(row.field_u8.unwrap().into())
+		})
+	);
+	assert_eq!(
+		select!(Vec<NameAndAgeResult> r#""Martin Luther" AS name, field_u8 AS age FROM personintegrationtest"#)
+			.unwrap(),
+		vec![
+			NameAndAgeResult {
+				name: Some("Martin Luther".into()),
+				age: Some(row.field_u8.unwrap().into())
+			}
+		]
+	);
+
 	assert_eq!(select!(Vec<PersonIntegrationTest>).unwrap(), vec![row.clone()]);
 	assert_eq!(select!(Option<PersonIntegrationTest>).unwrap(), Some(row.clone()));
 
@@ -200,17 +219,29 @@ fn integration_test() {
 	);
 
 	assert_eq!(
-		select!(String "field_string FROM personintegrationtest").unwrap(),
-		row.field_string.unwrap()
+		&select!(String "field_string FROM personintegrationtest").unwrap(),
+		row.field_string.as_ref().unwrap()
 	);
 
-	// assert_eq!(select!(Option<i64> "field_u8 FROM personintegrationtest").unwrap(), Some(row.field_u8.unwrap()));
+	assert_eq!(
+		select!(Option<i64> "field_u8 FROM personintegrationtest").unwrap(),
+		Some(row.field_u8.unwrap() as i64)
+	);
 	assert!(select!(i64 "field_u8 FROM personintegrationtest WHERE FALSE").is_err());
-	// assert_eq!(select!(Option<i64> "field_u8 FROM personintegrationtest WHERE ?", false).unwrap(), None);
+	assert_eq!(
+		select!(Option<i64> "field_u8 FROM personintegrationtest WHERE ?", false).unwrap(),
+		None
+	);
 
-	// assert_eq!(select!(Vec<i64> "field_u8 FROM personintegrationtest").unwrap(), row.field_u8.unwrap());
-	// assert_eq!(select!(Option<i64> "field_u8 FROM personintegrationtest").unwrap(), row.field_u8);
-	// assert_eq!(select!(String "field_string FROM personintegrationtest").unwrap(), row.field_string.unwrap());
+	assert_eq!(
+		select!(Vec<i64> "field_u8 FROM personintegrationtest").unwrap(),
+		vec![row.field_u8.unwrap() as i64]
+	);
+	assert_eq!(select!(Option<u8> "field_u8 FROM personintegrationtest").unwrap(), row.field_u8);
+	assert_eq!(
+		&select!(String "field_string FROM personintegrationtest").unwrap(),
+		row.field_string.as_ref().unwrap()
+	);
 
 	// future: tuples:
 	// let result = select!((String, i64) "name, age FROM person")?;


### PR DESCRIPTION
This fixes selecting for `Option<primitive type>` and `Vec<primitive type>`. It does so by breaking down the code gen for select into three components, one small snippet for how each row is handled depending on `content`, one small snippet for how the iterator over rows is handled depending on `container`, and one shared snippet that puts it all together.

The code it generates isn't identical to the original code, but I believe it's logically equivalent. Except for

 - The two cases mentioned above that weren't handled correctly before
 - Properly classifying u8 as a primitive type (it was missing from the list).
 - Collecting the rows iterator directly into the `Vec<OutputType>` instead of first allocating an intermediate `Vec` with `Results` un-flattened.

I uncommented some existing tests that checked these for correctness, as well as adding two additional tests for `Option<CustomStruct>` and `Vec<CustomStruct>` to complete the grid of possibilities (those tests pass before the changes as well).

I believe this bumps MSRV to 1.70, and it probably requires a CI change as a result, but before figuring that out I wanted to make sure you were ok with bumping the MSRV. I'm using it for `Option::is_some_and` (that I know about, I'm generally not very careful about not using new features so it wouldn't surprise me to find out I was using something else that bumped MSRV as well). If you're worried about that I can easily rewrite it to use older and only slightly clunkier syntax.

Thanks for a cool library :)