### PR TITLE
Make Blob a primitive type

### DIFF
--- a/turbosql-impl/src/lib.rs
+++ b/turbosql-impl/src/lib.rs
@@ -579,7 +579,7 @@ fn do_parse_tokens(
 	let content_ty;
 	match content {
 		Content::Ident(content)
-			if ["f32", "f64", "i8", "u8", "i16", "u16", "i32", "u32", "i64", "String", "bool"]
+			if ["f32", "f64", "i8", "u8", "i16", "u16", "i32", "u32", "i64", "String", "bool", "Blob"]
 				.contains(&content.to_string().as_str()) =>
 		{
 			handle_row = quote! { Ok(row.get(0)?) };

--- a/turbosql/tests/integration_test.rs
+++ b/turbosql/tests/integration_test.rs
@@ -38,7 +38,7 @@ fn integration_test() {
 		field_i64: Some(85262398562),
 		field_f64: Some(std::f64::consts::PI),
 		field_f32: Some(std::f32::consts::E),
-		field_blob: None,
+		field_blob: Some(vec![1, 2, 3]),
 		field_array_u8: Some([1u8; 99]),
 		field_serialize: Some(vec![42, 43]),
 		..Default::default()
@@ -196,6 +196,14 @@ fn integration_test() {
 		select!(i64 "field_u8 FROM personintegrationtest").unwrap(),
 		row.field_u8.unwrap() as i64
 	);
+	assert_eq!(
+		&select!(Blob "field_blob from personintegrationtest").unwrap(),
+		row.field_blob.as_ref().unwrap()
+	);
+	// assert_eq!(
+	// 	&select!([u8; 99] "field_array_u8 from personintegrationtest").unwrap(),
+	// 	row.field_array_u8.as_ref().unwrap()
+	// );
 
 	assert_eq!(
 		select!(bool "field_string = ? FROM personintegrationtest", "Arthur Schopenhauer").unwrap(),


### PR DESCRIPTION
There's a `pub type Blob = Vec<u8>` that's supported for defining struct fields, so it should be supported for fetching from struct fields as well. This also adds a disabled test for arrays but that needs #26 (or special cased type parsing).

Continuing the discussion started in #33 - I'm not using `Vec<u8>` as a multi-row select, but I do wonder if special casing it is worth the (user facing) complexity considering we already have the `Blob` typedef. It might be a better solution to detect when a user is selecting a (sql type)`BLOB` column into a multi-row-select `Vec<u8>` and print a warning suggesting that they probably want to specify the rust type as `Blob` instead.