### PR TITLE
Relax dependency version constraints

### DIFF
--- a/turbosql-impl/Cargo.toml
+++ b/turbosql-impl/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro-error = "1.0.0"
 proc-macro2 = "1.0.62"
 quote = "1.0.28"
 regex = "1.5.5"
-rusqlite = {version = "0.35.0", features = ["bundled", "blob", "column_decltype"]}
+rusqlite = {version = "^0.35", features = ["bundled", "blob", "column_decltype"]}
 serde = {version = "1.0.145", features = ["derive"]}
 syn = {version = "2.0.31", features = ["extra-traits", "full"]}
 toml = "0.8.0"

--- a/turbosql/Cargo.toml
+++ b/turbosql/Cargo.toml
@@ -18,7 +18,7 @@ turbosql-impl = {path = "../turbosql-impl", version = "=0.13.0"}
 directories-next = "2.0.0"
 log = "0.4.4"
 once_cell = "1.18.0"
-rusqlite = {version = "0.35.0", features = ["bundled", "blob"]}
+rusqlite = {version = "^0.35", features = ["bundled", "blob"]}
 serde = {version = "1.0.145", features = ["derive"]}
 serde_json = "1.0.0"
 thiserror = "1.0.7"


### PR DESCRIPTION
Using exact version dependencies (e.g., =0.35.0) for rusqlite can cause build conflicts because Cargo disallows multiple versions of crates linking to the same native(libsqlite3-sys) library in one project. Relaxing version constraints (e.g., using ^ ranges) lets Cargo unify dependencies, reducing the chance of multiple libsqlite3-sys versions and avoiding native library conflicts. This improves compatibility and makes integration easier for downstream users.